### PR TITLE
ufs-cli: ufseom: Randomize data pattern for both read and write

### DIFF
--- a/ufs-cli/ufs_eom.c
+++ b/ufs-cli/ufs_eom.c
@@ -52,6 +52,8 @@ struct EOMData {
 	int data_cnt;
 	int num_lanes;
 	int local_peer;
+	int gear;
+	int rate;
 
 	struct eom_result *er;
 } eom_data;
@@ -410,6 +412,7 @@ static int generate_eom_report(char *eom_file, struct EOMData *data)
 
 	fprintf(file, "UFS %s Side Eye Monitor Start\n", data->local_peer ? "Device" : "Host");
 	fprintf(file, "- - - - UFS INQUIRY ID: %s %s %s\n", mname, pname, pver);
+	fprintf(file, "- - - - UFS Gear Speed: HS-G%d Rate-%c\n", data->gear, data->rate == PA_HS_MODE_A ? 'A' : 'B');
 	fprintf(file, "EOM Capabilities:\n");
 	fprintf(file, "TimingMaxSteps %d TimingMaxOffset %d\n", data->timing_max_steps, data->timing_max_offset);
 	fprintf(file, "VoltageMaxSteps %d VoltageMaxOffset %d\n\n", data->voltage_max_steps, data->voltage_max_offset);
@@ -612,7 +615,7 @@ int main(int argc, char *argv[])
 	struct timespec ts_start, ts_end;
 	char tmp_file[1024], output_file[1024], eom_file_name[256], lane_str[8];
 	size_t eom_result_size;
-	int t, v, l, n, eom_cap, cur_gear, ret;
+	int t, v, l, n, eom_cap, cur_gear, cur_rate, ret;
 
 	init_eom_operation();
 
@@ -653,6 +656,20 @@ int main(int argc, char *argv[])
 		ret = ERROR;
 		goto close_bsg;
 	}
+
+	data->gear = cur_gear;
+
+	/* Get RX_HSRATE_Series */
+	cur_rate = uic_get(bsg_fd, UIC_ARG_MIB_SEL(RX_HSRATE_SERIES, SELECT_RX(0)), 0);
+	if (cur_rate < 0) {
+		pr_err("Failed to get current rate from RX_HSRATE_Series\n");
+		ret = ERROR;
+		goto close_bsg;
+	} else if (verbose) {
+		printf("RX_HSRATE_Series: %d\n", cur_rate);
+	}
+
+	data->rate = cur_rate;
 
 	if (!do_io)
 		goto skip_io_prepare;

--- a/ufs-cli/uic.h
+++ b/ufs-cli/uic.h
@@ -43,6 +43,7 @@
 #define PA_PWRMODE				0x1571
 #define PA_TXHSADAPTTYPE			0x15D4
 #define PA_RXGEAR				0x1583
+#define RX_HSRATE_SERIES			0xA2
 
 #define RX_EYEMON_START_MASK			0x1
 
@@ -56,6 +57,8 @@
 #define PA_INITIAL_ADAPT       0x01
 #define PA_NO_ADAPT            0x03
 
+#define PA_HS_MODE_A		1
+#define PA_HS_MODE_B		2
 
 enum uic_operation_mode {
 	GET,


### PR DESCRIPTION
To simulate real world data traffic, randomize data pattern for both read and write to stress the UFS link.